### PR TITLE
Add type information to `.is` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # Changelog
 
+## next
+\+ Add type information to `.is` checks.
+
+### Breaking changes
+
+All `.is` checks have been changed
+from computed properties to methods.
+
+Instead of
+`.isString`, `.isNumber`, `.isBoolean`, `.isNull`, `.isUndefined`, `.isObject`, and `.isArray`,
+use
+`.isString()`, `.isNumber()`, `.isBoolean()`, `.isNull()`, `.isUndefined()`, `.isObject()`, and `.isArray()`.
+
+Note that in some cases this change will _not_ cause a compiler error
+(e.g. `if (typedJSON.isNumber)` always succeeds)
+so each case should be checked by hand.
+
+This was forced by the fact that computed properties
+cannot return type information.
+
 ## 0.1.0
 \+ Add TypedJSON class.<br/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## next
-\+ Add type information to `.is` checks.
+\+ Add type information to `.is` checks.<br/>
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -56,19 +56,20 @@ const boolean = typedJSON5.boolean; // undefined
 // Instead, use .get().
 
 // Checks exists to check the type without getting the value:
-const isNumber = typedJSON5.isNumber // false
-const isString = typedJSON5.isString // true
-const isBoolean = typedJSON5.isBoolean // false
-const isArray = typedJSON5.isArray // false
-const isObject = typedJSON5.isObject // false
-const isNull = typedJSON5.isNull // false
-const isUndefined = typedJSON5.isUndefined // false
+const isNumber = typedJSON5.isNumber() // false
+const isString = typedJSON5.isString() // true
+const isBoolean = typedJSON5.isBoolean() // false
+const isArray = typedJSON5.isArray() // false
+const isObject = typedJSON5.isObject() // false
+const isNull = typedJSON5.isNull() // false
+const isUndefined = typedJSON5.isUndefined() // false
+// The type system is able to use the type information these return.
 
 // Invalid operations return either `undefined`
 // or a TypedJSON containing `undefined.
 const invalidJSON = TypedJSON.parse("invalid json");
-invalidJSON.isUndefined // true
-invalidJSON.get("a", 1, "b", 2).isUndefined // true
+invalidJSON.isUndefined() // true
+invalidJSON.get("a", 1, "b", 2).isUndefined() // true
 invalidJSON.number // undefined
 invalidJSON.stringify() // undefined
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { TypedJSON } from "./typed-json";
+export * from "./typed-json";

--- a/src/typed-json-interfaces.ts
+++ b/src/typed-json-interfaces.ts
@@ -1,5 +1,11 @@
 import { TypedJSON } from "./typed-json";
 
+// After a `.is` function returns true,
+// more specific descriptions of the types of a TypedJSON can be provided.
+// These interfaces are for the various `.is` functions.
+// Note they do not have documentation comments,
+// to avoid overriding the TypedJSON documentation comments.
+
 export interface StringJSON extends TypedJSON {
     readonly value: string;
     isString(): true;

--- a/src/typed-json-interfaces.ts
+++ b/src/typed-json-interfaces.ts
@@ -1,0 +1,120 @@
+import { TypedJSON } from "./typed-json";
+
+export interface StringJSON extends TypedJSON {
+    readonly value: string;
+    isString(): true;
+    readonly string: string;
+    isNumber(): false;
+    readonly number: undefined;
+    isBoolean(): false;
+    readonly boolean: undefined;
+    isNull(): false;
+    isUndefined(): false;
+    isArray(): false;
+    readonly array: undefined;
+    isObject(): false;
+    readonly object: undefined;
+    get(...keys: (string | number)[]): UndefinedJSON;
+}
+
+export interface NumberJSON extends TypedJSON {
+    readonly value: number;
+    isString(): false;
+    readonly string: undefined;
+    isNumber(): true;
+    readonly number: number;
+    isBoolean(): false;
+    readonly boolean: undefined;
+    isNull(): false;
+    isUndefined(): false;
+    isArray(): false;
+    readonly array: undefined;
+    isObject(): false;
+    readonly object: undefined;
+    get(...keys: (string | number)[]): UndefinedJSON;
+}
+
+export interface BooleanJSON extends TypedJSON {
+    readonly value: boolean;
+    isString(): false;
+    readonly string: undefined;
+    isNumber(): false;
+    readonly number: undefined;
+    isBoolean(): true;
+    readonly boolean: boolean;
+    isNull(): false;
+    isUndefined(): false;
+    isArray(): false;
+    readonly array: undefined;
+    isObject(): false;
+    readonly object: undefined;
+    get(...keys: (string | number)[]): UndefinedJSON;
+}
+
+export interface NullJSON extends TypedJSON {
+    readonly value: null;
+    isString(): false;
+    readonly string: undefined;
+    isNumber(): false;
+    readonly number: undefined;
+    isBoolean(): false;
+    readonly boolean: undefined;
+    isNull(): true;
+    isUndefined(): false;
+    isArray(): false;
+    readonly array: undefined;
+    isObject(): false;
+    readonly object: undefined;
+    get(...keys: (string | number)[]): UndefinedJSON;
+}
+
+export interface UndefinedJSON extends TypedJSON {
+    readonly value: undefined;
+    isString(): false;
+    readonly string: undefined;
+    isNumber(): false;
+    readonly number: undefined;
+    isBoolean(): false;
+    readonly boolean: undefined;
+    isNull(): false;
+    isUndefined(): true;
+    isArray(): false;
+    readonly array: undefined;
+    isObject(): false;
+    readonly object: undefined;
+    get(...keys: (string | number)[]): UndefinedJSON;
+}
+
+export interface ArrayJSON extends TypedJSON {
+    readonly value: any[];
+    isString(): false;
+    readonly string: undefined;
+    isNumber(): false;
+    readonly number: undefined;
+    isBoolean(): false;
+    readonly boolean: undefined;
+    isNull(): false;
+    isUndefined(): false;
+    isArray(): true;
+    readonly array: any[];
+    isObject(): false;
+    readonly object: undefined;
+    get(key: string, ...keys: (string | number)[]): UndefinedJSON;
+}
+
+export interface ObjectJSON extends TypedJSON {
+    readonly value: { [key: string]: any; };
+    isString(): false;
+    readonly string: undefined;
+    isNumber(): false;
+    readonly number: undefined;
+    isBoolean(): false;
+    readonly boolean: undefined;
+    isNull(): false;
+    isUndefined(): false;
+    isArray(): false;
+    readonly array: undefined;
+    isObject(): true;
+    readonly object: { [key: string]: any; };
+    get(key: number, ...keys: (string | number)[]): UndefinedJSON;
+}

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -1,3 +1,13 @@
+import {
+    ArrayJSON,
+    BooleanJSON,
+    NullJSON,
+    NumberJSON,
+    ObjectJSON,
+    StringJSON,
+    UndefinedJSON,
+} from "./typed-json-interfaces";
+
 /**
  * A type-safe representation of JSON data.
  *
@@ -56,7 +66,7 @@ export class TypedJSON {
     /**
      * `true` if this TypedJSON object represents a `string`.
      */
-    public get isString() {
+    public isString(): this is StringJSON {
         return typeof this.value === "string";
     }
 
@@ -65,13 +75,13 @@ export class TypedJSON {
      * or `undefined` if it is not a `string`.
      */
     public get string() {
-        if (this.isString) { return this.value as string; }
+        if (this.isString()) { return this.value as string; }
     }
 
     /**
      * `true` if this TypedJSON object represents a `number`.
      */
-    public get isNumber() {
+    public isNumber(): this is NumberJSON {
         return typeof this.value === "number";
     }
 
@@ -80,13 +90,13 @@ export class TypedJSON {
      * or `undefined` if it is not a `number`.
      */
     public get number() {
-        if (this.isNumber) { return this.value as number; }
+        if (this.isNumber()) { return this.value as number; }
     }
 
     /**
      * `true` if this TypedJSON object represents a `boolean`.
      */
-    public get isBoolean() {
+    public isBoolean(): this is BooleanJSON {
         return typeof this.value === "boolean";
     }
 
@@ -95,7 +105,7 @@ export class TypedJSON {
      * or `undefined` if it is not a `boolean`.
      */
     public get boolean() {
-        if (this.isBoolean) { return this.value as boolean; }
+        if (this.isBoolean()) { return this.value as boolean; }
     }
 
     /**
@@ -104,7 +114,7 @@ export class TypedJSON {
      * There is no `.null`
      * since there is only one possible `null` value.
      */
-    public get isNull() {
+    public isNull(): this is NullJSON {
         return this.value === null;
     }
 
@@ -114,14 +124,14 @@ export class TypedJSON {
      * There is no `.undefined`
      * since there is only one possible `undefined` value.
      */
-    public get isUndefined() {
+    public isUndefined(): this is UndefinedJSON {
         return this.value === undefined;
     }
 
     /**
      * `true` if this TypedJSON object is a array.
      */
-    public get isArray() {
+    public isArray(): this is ArrayJSON {
         return Array.isArray(this.value);
     }
 
@@ -133,14 +143,14 @@ export class TypedJSON {
      * instead of using the array directly.
      */
     public get array() {
-        if (this.isArray) { return this.value as any[]; }
+        if (this.isArray()) { return this.value as any[]; }
     }
 
     /**
      * `true` if this TypedJSON object is an object.
      */
-    public get isObject() {
-        return !this.isArray && !this.isNull && typeof this.value === "object";
+    public isObject(): this is ObjectJSON {
+        return !this.isArray() && !this.isNull() && typeof this.value === "object";
     }
 
     /**
@@ -151,7 +161,7 @@ export class TypedJSON {
      * instead of using the object directly.
      */
     public get object() {
-        if (this.isObject) { return this.value as { [key: string]: any }; }
+        if (this.isObject()) { return this.value as { [key: string]: any }; }
     }
 
     /**
@@ -171,11 +181,11 @@ export class TypedJSON {
      *
      * @param keys The chain of keys to the value to return.
      */
-    public get(...keys: (string | number)[]) {
+    public get(...keys: (string | number)[]): TypedJSON {
         let current: TypedJSON = this;
         for (const key of keys) {
             current = current._getSingle(key);
-            if (current.isUndefined) { break; }
+            if (current.isUndefined()) { break; }
         }
         return current;
     }

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -235,3 +235,13 @@ export class TypedJSON {
     }
 
 }
+
+export {
+    ArrayJSON,
+    BooleanJSON,
+    NullJSON,
+    NumberJSON,
+    ObjectJSON,
+    StringJSON,
+    UndefinedJSON,
+} from "./typed-json-interfaces";

--- a/test/typed-json-interfaces.test.ts
+++ b/test/typed-json-interfaces.test.ts
@@ -1,0 +1,348 @@
+import { assert } from "chai";
+import "mocha";
+import sinon = require("sinon");
+
+import { TypedJSON } from "../src/typed-json";
+import { ArrayJSON, BooleanJSON, NullJSON, NumberJSON, ObjectJSON, StringJSON, UndefinedJSON } from "../src/typed-json-interfaces";
+
+describe("typed-json-interfaces.ts", function () {
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe("StringJSON", function () {
+
+        it("is inferred for the correct type check", function () {
+            const typedJSON = new TypedJSON("any string");
+            if (typedJSON.isString()) {
+                const stringJSON: StringJSON = typedJSON;
+                assert.exists(stringJSON);
+            } else {
+                assert.fail();
+            }
+        });
+
+        it("allows correct type inference", function () {
+            const anyString = "any string";
+            const typedJSON = new TypedJSON(anyString);
+            if (typedJSON.isString()) {
+                const numberJSON: StringJSON = typedJSON;
+                const isString: true = numberJSON.isString();
+                const asString: string = numberJSON.string;
+                const isNumber: false = numberJSON.isNumber();
+                const asNumber: undefined = numberJSON.number;
+                const isBoolean: false = numberJSON.isBoolean();
+                const asBoolean: undefined = numberJSON.boolean;
+                const isNull: false = numberJSON.isNull();
+                const isUndefined: false = numberJSON.isUndefined();
+                const isArray: false = numberJSON.isArray();
+                const asArray: undefined = numberJSON.array;
+                const isObject: false = numberJSON.isObject();
+                const asObject: undefined = numberJSON.object;
+                assert.isTrue(isString);
+                assert.strictEqual(asString, anyString);
+                assert.isFalse(isNumber);
+                assert.isUndefined(asNumber);
+                assert.isFalse(isBoolean);
+                assert.isUndefined(asBoolean);
+                assert.isFalse(isNull);
+                assert.isFalse(isUndefined);
+                assert.isFalse(isArray);
+                assert.isUndefined(asArray);
+                assert.isFalse(isObject);
+                assert.isUndefined(asObject);
+            } else {
+                assert.fail();
+            }
+        });
+
+    });
+
+    describe("NumberJSON", function () {
+
+        it("is inferred for the correct type check", function () {
+            const typedJSON = new TypedJSON(0);
+            if (typedJSON.isNumber()) {
+                const numberJSON: NumberJSON = typedJSON;
+                assert.exists(numberJSON);
+            } else {
+                assert.fail();
+            }
+        });
+
+        it("allows correct type inference", function () {
+            const anyNumber = 0;
+            const typedJSON = new TypedJSON(anyNumber);
+            if (typedJSON.isNumber()) {
+                const numberJSON: NumberJSON = typedJSON;
+                const isString: false = numberJSON.isString();
+                const asString: undefined = numberJSON.string;
+                const isNumber: true = numberJSON.isNumber();
+                const asNumber: number = numberJSON.number;
+                const isBoolean: false = numberJSON.isBoolean();
+                const asBoolean: undefined = numberJSON.boolean;
+                const isNull: false = numberJSON.isNull();
+                const isUndefined: false = numberJSON.isUndefined();
+                const isArray: false = numberJSON.isArray();
+                const asArray: undefined = numberJSON.array;
+                const isObject: false = numberJSON.isObject();
+                const asObject: undefined = numberJSON.object;
+                assert.isFalse(isString);
+                assert.isUndefined(asString);
+                assert.isTrue(isNumber);
+                assert.strictEqual(asNumber, anyNumber);
+                assert.isFalse(isBoolean);
+                assert.isUndefined(asBoolean);
+                assert.isFalse(isNull);
+                assert.isFalse(isUndefined);
+                assert.isFalse(isArray);
+                assert.isUndefined(asArray);
+                assert.isFalse(isObject);
+                assert.isUndefined(asObject);
+            } else {
+                assert.fail();
+            }
+        });
+
+    });
+
+    describe("BooleanJSON", function () {
+
+        it("is inferred for the correct type check", function () {
+            const typedJSON = new TypedJSON(true);
+            if (typedJSON.isBoolean()) {
+                const booleanJSON: BooleanJSON = typedJSON;
+                assert.exists(booleanJSON);
+            } else {
+                assert.fail();
+            }
+        });
+
+        it("allows correct type inference", function () {
+            const anyBoolean = true;
+            const typedJSON = new TypedJSON(anyBoolean);
+            if (typedJSON.isBoolean()) {
+                const booleanJSON: BooleanJSON = typedJSON;
+                const isString: false = booleanJSON.isString();
+                const asString: undefined = booleanJSON.string;
+                const isNumber: false = booleanJSON.isNumber();
+                const asNumber: undefined = booleanJSON.number;
+                const isBoolean: true = booleanJSON.isBoolean();
+                const asBoolean: boolean = booleanJSON.boolean;
+                const isNull: false = booleanJSON.isNull();
+                const isUndefined: false = booleanJSON.isUndefined();
+                const isArray: false = booleanJSON.isArray();
+                const asArray: undefined = booleanJSON.array;
+                const isObject: false = booleanJSON.isObject();
+                const asObject: undefined = booleanJSON.object;
+                assert.isFalse(isString);
+                assert.isUndefined(asString);
+                assert.isFalse(isNumber);
+                assert.isUndefined(asNumber);
+                assert.isTrue(isBoolean);
+                assert.strictEqual(asBoolean, anyBoolean);
+                assert.isFalse(isNull);
+                assert.isFalse(isUndefined);
+                assert.isFalse(isArray);
+                assert.isUndefined(asArray);
+                assert.isFalse(isObject);
+                assert.isUndefined(asObject);
+            } else {
+                assert.fail();
+            }
+        });
+
+    });
+
+    describe("NullJSON", function () {
+
+        it("is inferred for the correct type check", function () {
+            const typedJSON = new TypedJSON(null);
+            if (typedJSON.isNull()) {
+                const nullJSON: NullJSON = typedJSON;
+                assert.exists(nullJSON);
+            } else {
+                assert.fail();
+            }
+        });
+
+        it("allows correct type inference", function () {
+            const typedJSON = new TypedJSON(null);
+            if (typedJSON.isNull()) {
+                const nullJSON: NullJSON = typedJSON;
+                const isString: false = nullJSON.isString();
+                const asString: undefined = nullJSON.string;
+                const isNumber: false = nullJSON.isNumber();
+                const asNumber: undefined = nullJSON.number;
+                const isBoolean: false = nullJSON.isBoolean();
+                const asBoolean: undefined = nullJSON.boolean;
+                const isNull: true = nullJSON.isNull();
+                const isUndefined: false = nullJSON.isUndefined();
+                const isArray: false = nullJSON.isArray();
+                const asArray: undefined = nullJSON.array;
+                const isObject: false = nullJSON.isObject();
+                const asObject: undefined = nullJSON.object;
+                assert.isFalse(isString);
+                assert.isUndefined(asString);
+                assert.isFalse(isNumber);
+                assert.isUndefined(asNumber);
+                assert.isFalse(isBoolean);
+                assert.isUndefined(asBoolean);
+                assert.isTrue(isNull);
+                assert.isFalse(isUndefined);
+                assert.isFalse(isArray);
+                assert.isUndefined(asArray);
+                assert.isFalse(isObject);
+                assert.isUndefined(asObject);
+            } else {
+                assert.fail();
+            }
+        });
+
+    });
+
+    describe("UndefinedJSON", function () {
+
+        it("is inferred for the correct type check", function () {
+            const typedJSON = new TypedJSON(undefined);
+            if (typedJSON.isUndefined()) {
+                const undefinedJSON: UndefinedJSON = typedJSON;
+                assert.exists(undefinedJSON);
+            } else {
+                assert.fail();
+            }
+        });
+
+        it("allows correct type inference", function () {
+            const typedJSON = new TypedJSON(undefined);
+            if (typedJSON.isUndefined()) {
+                const undefinedJSON: UndefinedJSON = typedJSON;
+                const isString: false = undefinedJSON.isString();
+                const asString: undefined = undefinedJSON.string;
+                const isNumber: false = undefinedJSON.isNumber();
+                const asNumber: undefined = undefinedJSON.number;
+                const isBoolean: false = undefinedJSON.isBoolean();
+                const asBoolean: undefined = undefinedJSON.boolean;
+                const isNull: false = undefinedJSON.isNull();
+                const isUndefined: true = undefinedJSON.isUndefined();
+                const isArray: false = undefinedJSON.isArray();
+                const asArray: undefined = undefinedJSON.array;
+                const isObject: false = undefinedJSON.isObject();
+                const asObject: undefined = undefinedJSON.object;
+                assert.isFalse(isString);
+                assert.isUndefined(asString);
+                assert.isFalse(isNumber);
+                assert.isUndefined(asNumber);
+                assert.isFalse(isBoolean);
+                assert.isUndefined(asBoolean);
+                assert.isFalse(isNull);
+                assert.isTrue(isUndefined);
+                assert.isFalse(isArray);
+                assert.isUndefined(asArray);
+                assert.isFalse(isObject);
+                assert.isUndefined(asObject);
+            } else {
+                assert.fail();
+            }
+        });
+
+    });
+
+    describe("ArrayJSON", function () {
+
+        it("is inferred for the correct type check", function () {
+            const typedJSON = new TypedJSON([]);
+            if (typedJSON.isArray()) {
+                const arrayJSON: ArrayJSON = typedJSON;
+                assert.exists(arrayJSON);
+            } else {
+                assert.fail();
+            }
+        });
+
+        it("allows correct type inference", function () {
+            const anyArray: any[] = [];
+            const typedJSON = new TypedJSON(anyArray);
+            if (typedJSON.isArray()) {
+                const arrayJSON: ArrayJSON = typedJSON;
+                const isString: false = arrayJSON.isString();
+                const asString: undefined = arrayJSON.string;
+                const isNumber: false = arrayJSON.isNumber();
+                const asNumber: undefined = arrayJSON.number;
+                const isBoolean: false = arrayJSON.isBoolean();
+                const asBoolean: undefined = arrayJSON.boolean;
+                const isNull: false = arrayJSON.isNull();
+                const isUndefined: false = arrayJSON.isUndefined();
+                const isArray: true = arrayJSON.isArray();
+                const asArray: any[] = arrayJSON.array;
+                const isObject: false = arrayJSON.isObject();
+                const asObject: undefined = arrayJSON.object;
+                assert.isFalse(isString);
+                assert.isUndefined(asString);
+                assert.isFalse(isNumber);
+                assert.isUndefined(asNumber);
+                assert.isFalse(isBoolean);
+                assert.isUndefined(asBoolean);
+                assert.isFalse(isNull);
+                assert.isFalse(isUndefined);
+                assert.isTrue(isArray);
+                assert.strictEqual(asArray, anyArray);
+                assert.isFalse(isObject);
+                assert.isUndefined(asObject);
+            } else {
+                assert.fail();
+            }
+        });
+
+    });
+
+    describe("ObjectJSON", function () {
+
+        it("is inferred for the correct type check", function () {
+            const typedJSON = new TypedJSON({});
+            if (typedJSON.isObject()) {
+                const objectJSON: ObjectJSON = typedJSON;
+                assert.exists(objectJSON);
+            } else {
+                assert.fail();
+            }
+        });
+
+        it("allows correct type inference", function () {
+            const anyObject = {};
+            const typedJSON = new TypedJSON(anyObject);
+            if (typedJSON.isObject()) {
+                const objectJSON: ObjectJSON = typedJSON;
+                const isString: false = objectJSON.isString();
+                const asString: undefined = objectJSON.string;
+                const isNumber: false = objectJSON.isNumber();
+                const asNumber: undefined = objectJSON.number;
+                const isBoolean: false = objectJSON.isBoolean();
+                const asBoolean: undefined = objectJSON.boolean;
+                const isNull: false = objectJSON.isNull();
+                const isUndefined: false = objectJSON.isUndefined();
+                const isArray: false = objectJSON.isArray();
+                const asArray: undefined = objectJSON.array;
+                const isObject: true = objectJSON.isObject();
+                const asObject: { [key: string]: any; } = objectJSON.object;
+                assert.isFalse(isString);
+                assert.isUndefined(asString);
+                assert.isFalse(isNumber);
+                assert.isUndefined(asNumber);
+                assert.isFalse(isBoolean);
+                assert.isUndefined(asBoolean);
+                assert.isFalse(isNull);
+                assert.isFalse(isUndefined);
+                assert.isFalse(isArray);
+                assert.isUndefined(asArray);
+                assert.isTrue(isObject);
+                assert.strictEqual(asObject, anyObject);
+            } else {
+                assert.fail();
+            }
+        });
+
+    });
+
+});

--- a/test/typed-json.test.ts
+++ b/test/typed-json.test.ts
@@ -50,16 +50,16 @@ describe("typed-json.ts", function () {
         describe(".isString", function () {
 
             it("should be true only if `.value` is a `string`", function () {
-                assert.isTrue(new TypedJSON("any string").isString);
-                assert.isFalse(new TypedJSON(9000).isString);
-                assert.isFalse(new TypedJSON(NaN).isString);
-                assert.isFalse(new TypedJSON(0).isString);
-                assert.isFalse(new TypedJSON(true).isString);
-                assert.isFalse(new TypedJSON(false).isString);
-                assert.isFalse(new TypedJSON(null).isString);
-                assert.isFalse(new TypedJSON(undefined).isString);
-                assert.isFalse(new TypedJSON({ string: "stringy" }).isString);
-                assert.isFalse(new TypedJSON(["string"]).isString);
+                assert.isTrue(new TypedJSON("any string").isString());
+                assert.isFalse(new TypedJSON(9000).isString());
+                assert.isFalse(new TypedJSON(NaN).isString());
+                assert.isFalse(new TypedJSON(0).isString());
+                assert.isFalse(new TypedJSON(true).isString());
+                assert.isFalse(new TypedJSON(false).isString());
+                assert.isFalse(new TypedJSON(null).isString());
+                assert.isFalse(new TypedJSON(undefined).isString());
+                assert.isFalse(new TypedJSON({ string: "stringy" }).isString());
+                assert.isFalse(new TypedJSON(["string"]).isString());
             });
 
         });
@@ -71,7 +71,7 @@ describe("typed-json.ts", function () {
                 assert.strictEqual(new TypedJSON(anyString).string, anyString);
             });
 
-            it("should be `.undefined` if it is not a `string`", function () {
+            it("should be `undefined` if it is not a `string`", function () {
                 assert.isUndefined(new TypedJSON({}).string);
             });
 
@@ -80,17 +80,17 @@ describe("typed-json.ts", function () {
         describe(".isNumber", function () {
 
             it("should be true only if `.value` is a `number`", function () {
-                assert.isFalse(new TypedJSON("number").isNumber);
-                assert.isFalse(new TypedJSON("9000").isNumber);
-                assert.isTrue(new TypedJSON(9000).isNumber);
-                assert.isTrue(new TypedJSON(NaN).isNumber);
-                assert.isTrue(new TypedJSON(0).isNumber);
-                assert.isFalse(new TypedJSON(true).isNumber);
-                assert.isFalse(new TypedJSON(false).isNumber);
-                assert.isFalse(new TypedJSON(null).isNumber);
-                assert.isFalse(new TypedJSON(undefined).isNumber);
-                assert.isFalse(new TypedJSON({ number: 9000 }).isNumber);
-                assert.isFalse(new TypedJSON([9000]).isNumber);
+                assert.isFalse(new TypedJSON("number").isNumber());
+                assert.isFalse(new TypedJSON("9000").isNumber());
+                assert.isTrue(new TypedJSON(9000).isNumber());
+                assert.isTrue(new TypedJSON(NaN).isNumber());
+                assert.isTrue(new TypedJSON(0).isNumber());
+                assert.isFalse(new TypedJSON(true).isNumber());
+                assert.isFalse(new TypedJSON(false).isNumber());
+                assert.isFalse(new TypedJSON(null).isNumber());
+                assert.isFalse(new TypedJSON(undefined).isNumber());
+                assert.isFalse(new TypedJSON({ number: 9000 }).isNumber());
+                assert.isFalse(new TypedJSON([9000]).isNumber());
             });
 
         });
@@ -111,16 +111,16 @@ describe("typed-json.ts", function () {
         describe(".isBoolean", function () {
 
             it("should be true only if `.value` is a `number`", function () {
-                assert.isFalse(new TypedJSON("number").isBoolean);
-                assert.isFalse(new TypedJSON(9000).isBoolean);
-                assert.isFalse(new TypedJSON(NaN).isBoolean);
-                assert.isFalse(new TypedJSON(0).isBoolean);
-                assert.isTrue(new TypedJSON(true).isBoolean);
-                assert.isTrue(new TypedJSON(false).isBoolean);
-                assert.isFalse(new TypedJSON(null).isBoolean);
-                assert.isFalse(new TypedJSON(undefined).isBoolean);
-                assert.isFalse(new TypedJSON({ boolean: true }).isBoolean);
-                assert.isFalse(new TypedJSON([true]).isBoolean);
+                assert.isFalse(new TypedJSON("number").isBoolean());
+                assert.isFalse(new TypedJSON(9000).isBoolean());
+                assert.isFalse(new TypedJSON(NaN).isBoolean());
+                assert.isFalse(new TypedJSON(0).isBoolean());
+                assert.isTrue(new TypedJSON(true).isBoolean());
+                assert.isTrue(new TypedJSON(false).isBoolean());
+                assert.isFalse(new TypedJSON(null).isBoolean());
+                assert.isFalse(new TypedJSON(undefined).isBoolean());
+                assert.isFalse(new TypedJSON({ boolean: true }).isBoolean());
+                assert.isFalse(new TypedJSON([true]).isBoolean());
             });
 
         });
@@ -141,54 +141,54 @@ describe("typed-json.ts", function () {
         describe(".isNull", function () {
 
             it("should be true only if `.value` is `null`", function () {
-                assert.isFalse(new TypedJSON("null").isNull);
-                assert.isFalse(new TypedJSON(9000).isNull);
-                assert.isFalse(new TypedJSON(NaN).isNull);
-                assert.isFalse(new TypedJSON(0).isNull);
-                assert.isFalse(new TypedJSON(true).isNull);
-                assert.isFalse(new TypedJSON(false).isNull);
-                assert.isTrue(new TypedJSON(null).isNull);
-                assert.isFalse(new TypedJSON(undefined).isNull);
-                assert.isFalse(new TypedJSON({}).isNull);
-                assert.isFalse(new TypedJSON([null]).isNull);
-                assert.isFalse(new TypedJSON([]).isNull);
+                assert.isFalse(new TypedJSON("null").isNull());
+                assert.isFalse(new TypedJSON(9000).isNull());
+                assert.isFalse(new TypedJSON(NaN).isNull());
+                assert.isFalse(new TypedJSON(0).isNull());
+                assert.isFalse(new TypedJSON(true).isNull());
+                assert.isFalse(new TypedJSON(false).isNull());
+                assert.isTrue(new TypedJSON(null).isNull());
+                assert.isFalse(new TypedJSON(undefined).isNull());
+                assert.isFalse(new TypedJSON({}).isNull());
+                assert.isFalse(new TypedJSON([null]).isNull());
+                assert.isFalse(new TypedJSON([]).isNull());
             });
 
         });
 
         describe(".isUndefined", function () {
 
-            it("should be true only if `.value` is `null`", function () {
-                assert.isFalse(new TypedJSON("undefined").isUndefined);
-                assert.isFalse(new TypedJSON(9000).isUndefined);
-                assert.isFalse(new TypedJSON(NaN).isUndefined);
-                assert.isFalse(new TypedJSON(0).isUndefined);
-                assert.isFalse(new TypedJSON(true).isUndefined);
-                assert.isFalse(new TypedJSON(false).isUndefined);
-                assert.isFalse(new TypedJSON(null).isUndefined);
-                assert.isTrue(new TypedJSON(undefined).isUndefined);
-                assert.isFalse(new TypedJSON({}).isUndefined);
-                assert.isFalse(new TypedJSON([undefined]).isUndefined);
-                assert.isFalse(new TypedJSON([]).isUndefined);
+            it("should be true only if `.value` is `undefined`", function () {
+                assert.isFalse(new TypedJSON("undefined").isUndefined());
+                assert.isFalse(new TypedJSON(9000).isUndefined());
+                assert.isFalse(new TypedJSON(NaN).isUndefined());
+                assert.isFalse(new TypedJSON(0).isUndefined());
+                assert.isFalse(new TypedJSON(true).isUndefined());
+                assert.isFalse(new TypedJSON(false).isUndefined());
+                assert.isFalse(new TypedJSON(null).isUndefined());
+                assert.isTrue(new TypedJSON(undefined).isUndefined());
+                assert.isFalse(new TypedJSON({}).isUndefined());
+                assert.isFalse(new TypedJSON([undefined]).isUndefined());
+                assert.isFalse(new TypedJSON([]).isUndefined());
             });
 
         });
 
         describe(".isObject", function () {
 
-            it("should be true only if `.value` is `null`", function () {
-                assert.isFalse(new TypedJSON("[object Object]").isObject);
-                assert.isFalse(new TypedJSON(9000).isObject);
-                assert.isFalse(new TypedJSON(NaN).isObject);
-                assert.isFalse(new TypedJSON(0).isObject);
-                assert.isFalse(new TypedJSON(true).isObject);
-                assert.isFalse(new TypedJSON(false).isObject);
-                assert.isFalse(new TypedJSON(null).isObject);
-                assert.isFalse(new TypedJSON(undefined).isObject);
-                assert.isFalse(new TypedJSON([{}, {}]).isObject);
-                assert.isFalse(new TypedJSON([]).isObject);
-                assert.isTrue(new TypedJSON({}).isObject);
-                assert.isTrue(new TypedJSON({ 0: 0, 1: 1, 2: 2, length: 3 }).isObject);
+            it("should be true only if `.value` is an object", function () {
+                assert.isFalse(new TypedJSON("[object Object]").isObject());
+                assert.isFalse(new TypedJSON(9000).isObject());
+                assert.isFalse(new TypedJSON(NaN).isObject());
+                assert.isFalse(new TypedJSON(0).isObject());
+                assert.isFalse(new TypedJSON(true).isObject());
+                assert.isFalse(new TypedJSON(false).isObject());
+                assert.isFalse(new TypedJSON(null).isObject());
+                assert.isFalse(new TypedJSON(undefined).isObject());
+                assert.isFalse(new TypedJSON([{}, {}]).isObject());
+                assert.isFalse(new TypedJSON([]).isObject());
+                assert.isTrue(new TypedJSON({}).isObject());
+                assert.isTrue(new TypedJSON({ 0: 0, 1: 1, 2: 2, length: 3 }).isObject());
             });
 
         });
@@ -208,19 +208,19 @@ describe("typed-json.ts", function () {
 
         describe(".isArray", function () {
 
-            it("should be true only if `.value` is `null`", function () {
-                assert.isFalse(new TypedJSON("[]").isArray);
-                assert.isFalse(new TypedJSON(9000).isArray);
-                assert.isFalse(new TypedJSON(NaN).isArray);
-                assert.isFalse(new TypedJSON(0).isArray);
-                assert.isFalse(new TypedJSON(true).isArray);
-                assert.isFalse(new TypedJSON(false).isArray);
-                assert.isFalse(new TypedJSON(null).isArray);
-                assert.isFalse(new TypedJSON(undefined).isArray);
-                assert.isTrue(new TypedJSON([{}, []]).isArray);
-                assert.isTrue(new TypedJSON([]).isArray);
-                assert.isFalse(new TypedJSON({}).isArray);
-                assert.isFalse(new TypedJSON({ 0: 0, 1: 1, 2: 2, length: 3 }).isArray);
+            it("should be true only if `.value` is an array", function () {
+                assert.isFalse(new TypedJSON("[]").isArray());
+                assert.isFalse(new TypedJSON(9000).isArray());
+                assert.isFalse(new TypedJSON(NaN).isArray());
+                assert.isFalse(new TypedJSON(0).isArray());
+                assert.isFalse(new TypedJSON(true).isArray());
+                assert.isFalse(new TypedJSON(false).isArray());
+                assert.isFalse(new TypedJSON(null).isArray());
+                assert.isFalse(new TypedJSON(undefined).isArray());
+                assert.isTrue(new TypedJSON([{}, []]).isArray());
+                assert.isTrue(new TypedJSON([]).isArray());
+                assert.isFalse(new TypedJSON({}).isArray());
+                assert.isFalse(new TypedJSON({ 0: 0, 1: 1, 2: 2, length: 3 }).isArray());
             });
 
         });
@@ -285,31 +285,31 @@ describe("typed-json.ts", function () {
             });
 
             it("should return an undefined `TypedJSON` for a single `number` argument", function () {
-                assert.isTrue(jsonArray.get(3).isUndefined);
+                assert.isTrue(jsonArray.get(3).isUndefined());
             });
 
             it("should return an undefined `TypedJSON` for a single `string` argument", function () {
-                assert.isTrue(jsonObject.get("b").isUndefined);
+                assert.isTrue(jsonObject.get("b").isUndefined());
             });
 
             it("should return an undefined `TypedJSON` for a single `number` argument on an object", function () {
-                assert.isTrue(jsonObject.get(0).isUndefined);
+                assert.isTrue(jsonObject.get(0).isUndefined());
             });
 
             it("should return an undefined `TypedJSON` for a single number `string` argument", function () {
-                assert.isTrue(jsonArray.get("1").isUndefined);
+                assert.isTrue(jsonArray.get("1").isUndefined());
             });
 
             it("should return an undefined `TypedJSON` for multiple arguments where the last does not exist", function () {
-                assert.isTrue(jsonArray.get("array", 1, "b").isUndefined);
+                assert.isTrue(jsonArray.get("array", 1, "b").isUndefined());
             });
 
             it("should return an undefined `TypedJSON` for multiple arguments where the last goes too far", function () {
-                assert.isTrue(jsonArray.get("array", 1, "a", 3).isUndefined);
+                assert.isTrue(jsonArray.get("array", 1, "a", 3).isUndefined());
             });
 
             it("should return an undefined `TypedJSON` for multiple arguments where the first does not exist", function () {
-                assert.isTrue(jsonArray.get("d", 1, "a", 3).isUndefined);
+                assert.isTrue(jsonArray.get("d", 1, "a", 3).isUndefined());
             });
 
         });
@@ -358,7 +358,7 @@ describe("typed-json.ts", function () {
             });
 
             it("should return a `TypedJSON` `null`", function () {
-                assert.isTrue(TypedJSON.parse("null").isNull);
+                assert.isTrue(TypedJSON.parse("null").isNull());
             });
 
             it("should return a `TypedJSON` `array`", function () {
@@ -370,7 +370,7 @@ describe("typed-json.ts", function () {
             });
 
             it("should return a `TypedJSON` `undefined` for unparsable JSON", function () {
-                assert.isTrue(TypedJSON.parse("nope").isUndefined);
+                assert.isTrue(TypedJSON.parse("nope").isUndefined());
             });
 
         });


### PR DESCRIPTION
For #1.

Adds interfaces for various kinds of `TypedJSON`s, which contain more specific information about what its methods will return.

- [x] All changes made.
- [x] Tests written or not required.
- [x] `npm test` passes.
- [x] `npm run coverage` shows 100% coverage.
- [x] Code changes have been read over.
