### PR TITLE
Document type information included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## next
+\* Improve documentation.<br/>
+
 ## 0.1.0
 \+ Add TypedJSON class.<br/>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ if (e === undefined) {
 
 Run `npm i typesafe-json` in your project.
 
+Type information is included automatically,
+`npm i @types/typesafe-json` is neither needed nor possible.
+
 ## Use
 
 ```ts


### PR DESCRIPTION
For #3.

Often, packages need an `@types` package to work with Typescript. This package does not, 

- [x] All changes made.
- [x] Tests written or not required.
- [x] `npm test` passes.
- [x] `npm run coverage` shows 100% coverage.
- [x] Code changes have been read over.
