### PR TITLE
Add `.keys()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## next
 \+ Add type information to `.is` checks.<br/>
+\+ Add `.keys()`.<br/>
 \* Replaced computed properties with methods.<br/>
 \* Improve documentation.<br/>
 

--- a/src/typed-json-interfaces.ts
+++ b/src/typed-json-interfaces.ts
@@ -20,6 +20,7 @@ export interface StringJSON extends TypedJSON {
     array(): undefined;
     isObject(): false;
     object(): undefined;
+    keys(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -37,6 +38,7 @@ export interface NumberJSON extends TypedJSON {
     array(): undefined;
     isObject(): false;
     object(): undefined;
+    keys(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -54,6 +56,7 @@ export interface BooleanJSON extends TypedJSON {
     array(): undefined;
     isObject(): false;
     object(): undefined;
+    keys(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -71,6 +74,7 @@ export interface NullJSON extends TypedJSON {
     array(): undefined;
     isObject(): false;
     object(): undefined;
+    keys(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -88,6 +92,7 @@ export interface UndefinedJSON extends TypedJSON {
     array(): undefined;
     isObject(): false;
     object(): undefined;
+    keys(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -105,6 +110,7 @@ export interface ArrayJSON extends TypedJSON {
     array(): any[];
     isObject(): false;
     object(): undefined;
+    keys(): number[];
     get(key: string, ...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -122,5 +128,6 @@ export interface ObjectJSON extends TypedJSON {
     array(): undefined;
     isObject(): true;
     object(): { [key: string]: any; };
+    keys(): string[];
     get(key: number, ...keys: (string | number)[]): UndefinedJSON;
 }

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -236,7 +236,7 @@ export class TypedJSON {
      * The type is `(string | number)[]`
      * instead of `string[] | number[]`
      * because functions such as `sort` and `map`
-     * have difficulties with `(string | number)[]`.
+     * have difficulties with `string[] | number[]`.
      *
      * Useful for iterating through TypedJSON objects.
      * For example,

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -225,9 +225,18 @@ export class TypedJSON {
     /**
      * Returns an array of the keys of this TypedJSON object.
      *
-     * This array is a `string[]` if this this TypedJSON is an `object`,
+     * This array is a `string[]` if this TypedJSON is an `object`,
      * a `number[]` if this TypedJSON is an array,
      * or an empty array if this TypedJSON is anything else.
+     *
+     * If this TypedJSON's value is an array
+     * with some `string` or `Symbol` keys,
+     * these keys are ignored.
+     *
+     * The type is `(string | number)[]`
+     * instead of `string[] | number[]`
+     * because functions such as `sort` and `map`
+     * have difficulties with `(string | number)[]`.
      *
      * Useful for iterating through TypedJSON objects.
      * For example,
@@ -238,15 +247,21 @@ export class TypedJSON {
      *  }
      * ```
      */
-    public keys(): string[] | number[] {
+    public keys(): (string | number)[] {
         const asObject = this.object();
         if (asObject) {
             return Object.keys(asObject);
         }
+
         const asArray = this.array();
         if (asArray) {
-            return Object.keys(asArray).map((key) => parseInt(key, 10));
+            return Object.keys(asArray)
+                .map((key) => {
+                    return parseInt(key, 10);
+                })
+                .filter((key) => !isNaN(key));
         }
+
         return [];
     }
 

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -223,6 +223,34 @@ export class TypedJSON {
     }
 
     /**
+     * Returns an array of the keys of this TypedJSON object.
+     *
+     * This array is a `string[]` if this this TypedJSON is an `object`,
+     * a `number[]` if this TypedJSON is an array,
+     * or an empty array if this TypedJSON is anything else.
+     *
+     * Useful for iterating through TypedJSON objects.
+     * For example,
+     * ```ts
+     *  for (const key of typedJSON.keys()) {
+     *      const value = typedJSON.get(value);
+     *      // Do something with `key` and `value`
+     *  }
+     * ```
+     */
+    public keys(): string[] | number[] {
+        const asObject = this.object();
+        if (asObject) {
+            return Object.keys(asObject);
+        }
+        const asArray = this.array();
+        if (asArray) {
+            return Object.keys(asArray).map((key) => parseInt(key, 10));
+        }
+        return [];
+    }
+
+    /**
      * Returns a JSON string representing this TypedJSON object,
      * or undefined, if it is not a valid JSON object.
      */

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -233,6 +233,10 @@ export class TypedJSON {
      * with some `string` or `Symbol` keys,
      * these keys are ignored.
      *
+     * If this TypedJSON's value is an object
+     * with some `Symbol` keys,
+     * these keys are ignored.
+     *
      * The type is `(string | number)[]`
      * instead of `string[] | number[]`
      * because functions such as `sort` and `map`

--- a/test/typed-json-interfaces.test.ts
+++ b/test/typed-json-interfaces.test.ts
@@ -27,19 +27,20 @@ describe("typed-json-interfaces.ts", function () {
             const anyString = "any string";
             const typedJSON = new TypedJSON(anyString);
             if (typedJSON.isString()) {
-                const numberJSON: StringJSON = typedJSON;
-                const isString: true = numberJSON.isString();
-                const asString: string = numberJSON.string();
-                const isNumber: false = numberJSON.isNumber();
-                const asNumber: undefined = numberJSON.number();
-                const isBoolean: false = numberJSON.isBoolean();
-                const asBoolean: undefined = numberJSON.boolean();
-                const isNull: false = numberJSON.isNull();
-                const isUndefined: false = numberJSON.isUndefined();
-                const isArray: false = numberJSON.isArray();
-                const asArray: undefined = numberJSON.array();
-                const isObject: false = numberJSON.isObject();
-                const asObject: undefined = numberJSON.object();
+                const stringJSON: StringJSON = typedJSON;
+                const isString: true = stringJSON.isString();
+                const asString: string = stringJSON.string();
+                const isNumber: false = stringJSON.isNumber();
+                const asNumber: undefined = stringJSON.number();
+                const isBoolean: false = stringJSON.isBoolean();
+                const asBoolean: undefined = stringJSON.boolean();
+                const isNull: false = stringJSON.isNull();
+                const isUndefined: false = stringJSON.isUndefined();
+                const isArray: false = stringJSON.isArray();
+                const asArray: undefined = stringJSON.array();
+                const isObject: false = stringJSON.isObject();
+                const asObject: undefined = stringJSON.object();
+                const keys: never[] = stringJSON.keys();
                 assert.isTrue(isString);
                 assert.strictEqual(asString, anyString);
                 assert.isFalse(isNumber);
@@ -52,6 +53,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isUndefined(asArray);
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
+                assert.isEmpty(keys);
             } else {
                 assert.fail();
             }
@@ -88,6 +90,7 @@ describe("typed-json-interfaces.ts", function () {
                 const asArray: undefined = numberJSON.array();
                 const isObject: false = numberJSON.isObject();
                 const asObject: undefined = numberJSON.object();
+                const keys: never[] = numberJSON.keys();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isTrue(isNumber);
@@ -100,6 +103,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isUndefined(asArray);
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
+                assert.isEmpty(keys);
             } else {
                 assert.fail();
             }
@@ -136,6 +140,7 @@ describe("typed-json-interfaces.ts", function () {
                 const asArray: undefined = booleanJSON.array();
                 const isObject: false = booleanJSON.isObject();
                 const asObject: undefined = booleanJSON.object();
+                const keys: never[] = booleanJSON.keys();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -148,6 +153,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isUndefined(asArray);
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
+                assert.isEmpty(keys);
             } else {
                 assert.fail();
             }
@@ -183,6 +189,7 @@ describe("typed-json-interfaces.ts", function () {
                 const asArray: undefined = nullJSON.array();
                 const isObject: false = nullJSON.isObject();
                 const asObject: undefined = nullJSON.object();
+                const keys: never[] = nullJSON.keys();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -195,6 +202,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isUndefined(asArray);
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
+                assert.isEmpty(keys);
             } else {
                 assert.fail();
             }
@@ -230,6 +238,7 @@ describe("typed-json-interfaces.ts", function () {
                 const asArray: undefined = undefinedJSON.array();
                 const isObject: false = undefinedJSON.isObject();
                 const asObject: undefined = undefinedJSON.object();
+                const keys: never[] = undefinedJSON.keys();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -242,6 +251,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isUndefined(asArray);
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
+                assert.isEmpty(keys);
             } else {
                 assert.fail();
             }
@@ -278,6 +288,7 @@ describe("typed-json-interfaces.ts", function () {
                 const asArray: any[] = arrayJSON.array();
                 const isObject: false = arrayJSON.isObject();
                 const asObject: undefined = arrayJSON.object();
+                const keys: number[] = arrayJSON.keys();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -290,6 +301,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.strictEqual(asArray, anyArray);
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
+                assert.isArray(keys);
             } else {
                 assert.fail();
             }
@@ -326,6 +338,7 @@ describe("typed-json-interfaces.ts", function () {
                 const asArray: undefined = objectJSON.array();
                 const isObject: true = objectJSON.isObject();
                 const asObject: { [key: string]: any; } = objectJSON.object();
+                const keys: string[] = objectJSON.keys();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -338,6 +351,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isUndefined(asArray);
                 assert.isTrue(isObject);
                 assert.strictEqual(asObject, anyObject);
+                assert.isArray(keys);
             } else {
                 assert.fail();
             }

--- a/test/typed-json.test.ts
+++ b/test/typed-json.test.ts
@@ -314,6 +314,47 @@ describe("typed-json.ts", function () {
 
         });
 
+        describe(".keys", function () {
+
+            it("should return the correct array of strings for a `TypedJSON` containing an `object`", function () {
+                const typedJSON = new TypedJSON({
+                    1: "any value",
+                    // This test is testing strange objects, so it requires strange code.
+                    // tslint:disable-next-line:object-literal-key-quotes
+                    "2": "any value",
+                    someOtherKey: "any value",
+                });
+                assert.deepEqual(typedJSON.keys().sort(), ["1", "2", "someOtherKey"].sort());
+            });
+
+            it("should return the correct array of numbers for a `TypedJSON` containing an `array`", function () {
+                const typedJSON = new TypedJSON([7, "any value", {}]);
+                assert.deepEqual(typedJSON.keys().sort(), [0, 1, 2].sort());
+            });
+
+            it("should ignore non-numeric keys in an array", function () {
+                const array: any = [7, "any value", {}];
+                array["someOtherKey"] = "any value";
+                array[100] = "any value";
+                const typedJSON = new TypedJSON(array);
+                assert.deepEqual(typedJSON.keys().sort(), [0, 1, 2, 100].sort());
+            });
+
+            it("should return an empty array for a `TypedJSON` containing neither an `array` nor an `object`", function () {
+                assert.isEmpty(new TypedJSON(0).keys());
+                assert.isEmpty(new TypedJSON(true).keys());
+                assert.isEmpty(new TypedJSON(false).keys());
+                assert.isEmpty(new TypedJSON(null).keys());
+                assert.isEmpty(new TypedJSON(undefined).keys());
+            });
+
+            it("should return an empty array for a `TypedJSON` containing an empty `array` or `object`", function () {
+                assert.isEmpty(new TypedJSON({}).keys());
+                assert.isEmpty(new TypedJSON({}).keys());
+            });
+
+        });
+
         describe(".stringify", function () {
 
             it("should return a string representing the TypedJSON", function () {

--- a/test/typed-json.test.ts
+++ b/test/typed-json.test.ts
@@ -349,7 +349,7 @@ describe("typed-json.ts", function () {
             });
 
             it("should return an empty array for a `TypedJSON` containing an empty `array` or `object`", function () {
-                assert.isEmpty(new TypedJSON({}).keys());
+                assert.isEmpty(new TypedJSON([]).keys());
                 assert.isEmpty(new TypedJSON({}).keys());
             });
 


### PR DESCRIPTION
For #25.

Adds a `.keys()` function that returns the keys to arrays or objects, or an empty array for other types.

- [x] All changes made.
- [x] Tests written or not required.
- [x] `npm test` passes.
- [x] `npm run coverage` shows 100% coverage.
- [x] Code changes have been read over.
- [x] Code actually works.
- [x] The changelog has been updated, if necessary.
