### PR TITLE
Add documentation about values type

### DIFF
--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -58,6 +58,9 @@ export class TypedJSON {
     /**
      * The raw JS object underlying this value.
      *
+     * Should be of type `unknown`,
+     * but is of type `any` for backwards compatibility reasons.
+     *
      * Prefer to access it through other methods,
      * unless you have some reason to access it directly.
      */


### PR DESCRIPTION
For #19.

`.value` should be `unknown`, but many people still use TS2, which doesn't support `unknown`. This PR adds documentation instructing users to treat it as `unknown`.

- [x] All changes made.
- [ ] Tests written or not required.
- [ ] `npm test` passes.
- [ ] `npm run coverage` shows 100% coverage.
- [ ] The changelog has been updated, if necessary.
