### PR TITLE
Add `.values()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## next
 \+ Add type information to `.is` checks.<br/>
+\+ Add `.values()`.<br/>
 \* Replaced computed properties with methods.<br/>
 \* Improve documentation.<br/>
 

--- a/src/typed-json-interfaces.ts
+++ b/src/typed-json-interfaces.ts
@@ -21,6 +21,7 @@ export interface StringJSON extends TypedJSON {
     isObject(): false;
     object(): undefined;
     keys(): never[];
+    values(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -39,6 +40,7 @@ export interface NumberJSON extends TypedJSON {
     isObject(): false;
     object(): undefined;
     keys(): never[];
+    values(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -57,6 +59,7 @@ export interface BooleanJSON extends TypedJSON {
     isObject(): false;
     object(): undefined;
     keys(): never[];
+    values(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -75,6 +78,7 @@ export interface NullJSON extends TypedJSON {
     isObject(): false;
     object(): undefined;
     keys(): never[];
+    values(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -93,6 +97,7 @@ export interface UndefinedJSON extends TypedJSON {
     isObject(): false;
     object(): undefined;
     keys(): never[];
+    values(): never[];
     get(...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -111,6 +116,7 @@ export interface ArrayJSON extends TypedJSON {
     isObject(): false;
     object(): undefined;
     keys(): number[];
+    values(): TypedJSON[];
     get(key: string, ...keys: (string | number)[]): UndefinedJSON;
 }
 
@@ -129,5 +135,6 @@ export interface ObjectJSON extends TypedJSON {
     isObject(): true;
     object(): { [key: string]: any; };
     keys(): string[];
+    values(): TypedJSON[];
     get(key: number, ...keys: (string | number)[]): UndefinedJSON;
 }

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -266,6 +266,31 @@ export class TypedJSON {
     }
 
     /**
+     * Returns an array TypedJSON objects
+     * containing the values of this TypedJSON.
+     *
+     * If this TypedJSON is an `object`,
+     * it returns the values of the `object` wrapped in TypedJSON objects.
+     * If this TypedJSON is an `array`,
+     * it returns the values of the `array` wrapped in TypedJSON objects.
+     * Otherwise, it returns an empty array.
+     *
+     * If this TypedJSON holds an array with nonnumeric keys,
+     * those values are omitted.
+     *
+     * Useful for iterating through TypedJSON objects.
+     * For example,
+     * ```ts
+     *  for (const value of typedJSON.value()) {
+     *      // Do something with the `value`
+     *  }
+     * ```
+     */
+    public values(): TypedJSON[] {
+        return this.keys().map((key) => this.get(key));
+    }
+
+    /**
      * Returns a JSON string representing this TypedJSON object,
      * or undefined, if it is not a valid JSON object.
      */

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -246,6 +246,9 @@ export class TypedJSON {
      *      // Do something with `key` and `value`
      *  }
      * ```
+     *
+     * Use `.values()` to get an array of only values
+     * if only values are needed instead.
      */
     public keys(): (string | number)[] {
         const asObject = this.object();
@@ -285,6 +288,8 @@ export class TypedJSON {
      *      // Do something with the `value`
      *  }
      * ```
+     *
+     * Use `.keys()` if the keys are needed instead of the values.
      */
     public values(): TypedJSON[] {
         return this.keys().map((key) => this.get(key));

--- a/test/typed-json-interfaces.test.ts
+++ b/test/typed-json-interfaces.test.ts
@@ -41,6 +41,7 @@ describe("typed-json-interfaces.ts", function () {
                 const isObject: false = stringJSON.isObject();
                 const asObject: undefined = stringJSON.object();
                 const keys: never[] = stringJSON.keys();
+                const values: never[] = stringJSON.values();
                 assert.isTrue(isString);
                 assert.strictEqual(asString, anyString);
                 assert.isFalse(isNumber);
@@ -54,6 +55,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
                 assert.isEmpty(keys);
+                assert.isEmpty(values);
             } else {
                 assert.fail();
             }
@@ -91,6 +93,7 @@ describe("typed-json-interfaces.ts", function () {
                 const isObject: false = numberJSON.isObject();
                 const asObject: undefined = numberJSON.object();
                 const keys: never[] = numberJSON.keys();
+                const values: never[] = numberJSON.values();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isTrue(isNumber);
@@ -104,6 +107,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
                 assert.isEmpty(keys);
+                assert.isEmpty(values);
             } else {
                 assert.fail();
             }
@@ -141,6 +145,7 @@ describe("typed-json-interfaces.ts", function () {
                 const isObject: false = booleanJSON.isObject();
                 const asObject: undefined = booleanJSON.object();
                 const keys: never[] = booleanJSON.keys();
+                const values: never[] = booleanJSON.values();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -154,6 +159,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
                 assert.isEmpty(keys);
+                assert.isEmpty(values);
             } else {
                 assert.fail();
             }
@@ -190,6 +196,7 @@ describe("typed-json-interfaces.ts", function () {
                 const isObject: false = nullJSON.isObject();
                 const asObject: undefined = nullJSON.object();
                 const keys: never[] = nullJSON.keys();
+                const values: never[] = nullJSON.values();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -203,6 +210,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
                 assert.isEmpty(keys);
+                assert.isEmpty(values);
             } else {
                 assert.fail();
             }
@@ -239,6 +247,7 @@ describe("typed-json-interfaces.ts", function () {
                 const isObject: false = undefinedJSON.isObject();
                 const asObject: undefined = undefinedJSON.object();
                 const keys: never[] = undefinedJSON.keys();
+                const values: never[] = undefinedJSON.values();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -252,6 +261,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
                 assert.isEmpty(keys);
+                assert.isEmpty(values);
             } else {
                 assert.fail();
             }
@@ -289,6 +299,7 @@ describe("typed-json-interfaces.ts", function () {
                 const isObject: false = arrayJSON.isObject();
                 const asObject: undefined = arrayJSON.object();
                 const keys: number[] = arrayJSON.keys();
+                const values: TypedJSON[] = arrayJSON.values();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -302,6 +313,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isFalse(isObject);
                 assert.isUndefined(asObject);
                 assert.isArray(keys);
+                assert.isArray(values);
             } else {
                 assert.fail();
             }
@@ -339,6 +351,7 @@ describe("typed-json-interfaces.ts", function () {
                 const isObject: true = objectJSON.isObject();
                 const asObject: { [key: string]: any; } = objectJSON.object();
                 const keys: string[] = objectJSON.keys();
+                const values: TypedJSON[] = objectJSON.values();
                 assert.isFalse(isString);
                 assert.isUndefined(asString);
                 assert.isFalse(isNumber);
@@ -352,6 +365,7 @@ describe("typed-json-interfaces.ts", function () {
                 assert.isTrue(isObject);
                 assert.strictEqual(asObject, anyObject);
                 assert.isArray(keys);
+                assert.isArray(values);
             } else {
                 assert.fail();
             }

--- a/test/typed-json.test.ts
+++ b/test/typed-json.test.ts
@@ -355,6 +355,47 @@ describe("typed-json.ts", function () {
 
         });
 
+        describe(".values", function () {
+
+            it("should return the correct array of `TypedJSON` objects for a `TypedJSON` containing an `object`", function () {
+                const typedJSON = new TypedJSON({
+                    1: "some value",
+                    // This test is testing strange objects, so it requires strange code.
+                    // tslint:disable-next-line:object-literal-key-quotes
+                    "2": 123,
+                    someOtherKey: undefined,
+                });
+                assert.deepEqual(typedJSON.values().map((typedJSON) => typedJSON.value).sort(), ["some value", 123, undefined].sort());
+            });
+
+            it("should return the correct array of `TypedJSON` objects for a `TypedJSON` containing an `array`", function () {
+                const typedJSON = new TypedJSON([7, "any value", {}]);
+                assert.deepEqual(typedJSON.values().map((typedJSON) => typedJSON.value), [7, "any value", {}]);
+            });
+
+            it("should ignore non-numeric keys in an array", function () {
+                const array: any = [7, "any value", {}];
+                array["someOtherKey"] = "any other value";
+                array[100] = "any third value";
+                const typedJSON = new TypedJSON(array);
+                assert.deepEqual(typedJSON.values().map((typedJSON) => typedJSON.value), [7, "any value", {}, "any third value"]);
+            });
+
+            it("should return an empty array for a `TypedJSON` containing neither an `array` nor an `object`", function () {
+                assert.isEmpty(new TypedJSON(0).values());
+                assert.isEmpty(new TypedJSON(true).values());
+                assert.isEmpty(new TypedJSON(false).values());
+                assert.isEmpty(new TypedJSON(null).values());
+                assert.isEmpty(new TypedJSON(undefined).values());
+            });
+
+            it("should return an empty array for a `TypedJSON` containing an empty `array` or `object`", function () {
+                assert.isEmpty(new TypedJSON({}).values());
+                assert.isEmpty(new TypedJSON({}).values());
+            });
+
+        });
+
         describe(".stringify", function () {
 
             it("should return a string representing the TypedJSON", function () {


### PR DESCRIPTION
For #34.

This PR adds `.values()`.

- [x] All changes made.
- [x] Code changes have been read over.
- [x] Code actually works.
- [x] Tests written or not required.
- [x] `npm test` passes.
- [x] `npm run coverage` shows 100% coverage.
- [x] The changelog has been updated, if necessary.
