### PR TITLE
Guarantee order of `.keys()` and `.values()` for arrays

### DIFF
--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -232,9 +232,10 @@ export class TypedJSON {
      * a `number[]` if this TypedJSON is an array,
      * or an empty array if this TypedJSON is anything else.
      *
-     * If this TypedJSON's value is an array
-     * with some `string` or `Symbol` keys,
-     * these keys are ignored.
+     * If this TypedJSON's value is an array,
+     * only non-negative integers
+     * will be included in the resulting array,
+     * in ascending order.
      *
      * If this TypedJSON's value is an object
      * with some `Symbol` keys,
@@ -286,8 +287,10 @@ export class TypedJSON {
      * it returns the values of the `array` wrapped in TypedJSON objects.
      * Otherwise, it returns an empty array.
      *
-     * If this TypedJSON holds an array with nonnumeric keys,
-     * those values are omitted.
+     * If this TypedJSON's value is an array,
+     * only values with non-negative integer keys
+     * will be included in the resulting array,
+     * in ascending order.
      *
      * Useful for iterating through TypedJSON objects.
      * For example,

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -269,7 +269,7 @@ export class TypedJSON {
                 .map((key) => {
                     return parseInt(key, 10);
                 })
-                .filter((key) => !isNaN(key))
+                .filter((key) => !isNaN(key) && key >= 0)
                 .sort((a, b) => a - b);
         }
 

--- a/src/typed-json.ts
+++ b/src/typed-json.ts
@@ -269,7 +269,8 @@ export class TypedJSON {
                 .map((key) => {
                     return parseInt(key, 10);
                 })
-                .filter((key) => !isNaN(key));
+                .filter((key) => !isNaN(key))
+                .sort((a, b) => a - b);
         }
 
         return [];

--- a/test/typed-json.test.ts
+++ b/test/typed-json.test.ts
@@ -353,6 +353,17 @@ describe("typed-json.ts", function () {
                 assert.isEmpty(new TypedJSON({}).keys());
             });
 
+            it("should be in order for a `TypedJSON` containing an `array`", function () {
+                const array: any = [0, 1, 2];
+                array[10] = 10;
+                array[1] = 1;
+                array[5] = 5;
+                array["string"] = "string";
+                array[-1] = -1;
+
+                assert.deepEqual(new TypedJSON(array).keys(), [-1, 0, 1, 2, 5, 10]);
+            });
+
         });
 
         describe(".values", function () {
@@ -392,6 +403,17 @@ describe("typed-json.ts", function () {
             it("should return an empty array for a `TypedJSON` containing an empty `array` or `object`", function () {
                 assert.isEmpty(new TypedJSON({}).values());
                 assert.isEmpty(new TypedJSON({}).values());
+            });
+
+            it("should be in order for a `TypedJSON` containing an `array`", function () {
+                const array: any = [0, 1, 2];
+                array[10] = 10;
+                array[1] = 1;
+                array[5] = 5;
+                array["string"] = "string";
+                array[-1] = -1;
+
+                assert.deepEqual(new TypedJSON(array).values().map((typedJSON) => typedJSON.value), [-1, 0, 1, 2, 5, 10]);
             });
 
         });

--- a/test/typed-json.test.ts
+++ b/test/typed-json.test.ts
@@ -361,7 +361,7 @@ describe("typed-json.ts", function () {
                 array["string"] = "string";
                 array[-1] = -1;
 
-                assert.deepEqual(new TypedJSON(array).keys(), [-1, 0, 1, 2, 5, 10]);
+                assert.deepEqual(new TypedJSON(array).keys(), [0, 1, 2, 5, 10]);
             });
 
         });
@@ -413,7 +413,7 @@ describe("typed-json.ts", function () {
                 array["string"] = "string";
                 array[-1] = -1;
 
-                assert.deepEqual(new TypedJSON(array).values().map((typedJSON) => typedJSON.value), [-1, 0, 1, 2, 5, 10]);
+                assert.deepEqual(new TypedJSON(array).values().map((typedJSON) => typedJSON.value), [0, 1, 2, 5, 10]);
             });
 
         });


### PR DESCRIPTION
For #37 .

This changes the output of `.keys()` and `.values()` on arrays so that it only includes nonnegative integers and is always ascending.

- [x] All changes made.
- [x] Code changes have been read over.
- [x] Code actually works.
- [x] Tests written or not required.
- [x] `npm test` passes.
- [x] `npm run coverage` shows 100% coverage.
- [x] The changelog has been updated, if necessary.
