### PR TITLE
Stop providing command for installing nonexistent directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ if (e === undefined) {
 
 Run `npm i typesafe-json` in your project.
 
-Type information is included automatically,
-`npm i @types/typesafe-json` is neither needed nor possible.
+Type information is included automatically.
+Don't install `@types/typesafe-json`,
+is it neither needed nor possible.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ if (e === undefined) {
 Run `npm i typesafe-json` in your project.
 
 Type information is included automatically.
-Don't install `@types/typesafe-json`,
-is it neither needed nor possible.
+Don't install `@types/typesafe-json`;
+it is neither needed nor possible.
 
 ## Use
 


### PR DESCRIPTION
For #39.

This PR gets rid of a command that would fail from the documentation. The documentation says not to run it, so it seems kind of silly to make it so easy for users to run it.

- [x] All changes made.
- [x] Tests written or not required.
- [x] `npm test` passes.
- [x] `npm run coverage` shows 100% coverage.
- [x] The changelog has been updated, if necessary.
