### PR TITLE
Add typechecking for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "prepack": "npm run build -s",
         "prepublishOnly": "npm run test -s",
         "test": "npm run typecheck -s && npm run lint -s && npm run mocha -s",
-        "typecheck": "tsc --noEmit"
+        "typecheck": "tsc --noEmit && tsc --project test"
     },
     "repository": {
         "type": "git",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "..",
+    "compilerOptions": {
+        "noEmit": true
+    },
+    "include": [
+        "./**/*"
+    ]
+}


### PR DESCRIPTION
For #58.

Previously, `npm run typecheck` ignored the tests.
It no longer does.

- [x] All changes made.
- [x] Changes have been read over.
- [x] Code changes, if there are any, actually work.
- [x] Tests written or not required.
- [x] `npm test` passes.
- [x] `npm run coverage` shows 100% coverage.
- [x] The changelog has been updated, if necessary.
